### PR TITLE
Added Trim a binary search tree

### DIFF
--- a/ContainerWithMostWater
+++ b/ContainerWithMostWater
@@ -1,0 +1,22 @@
+class Solution {
+public:
+    int maxArea(vector<int>& height) {
+        int beginning=0, end=height.size()-1,max_area=0;
+    
+        
+        while(beginning<=end)
+        {
+        int minimum_height=min(height[beginning],height[end]);
+        max_area=max(minimum_height * (end-beginning) , max_area);
+        if(height[beginning]<=height[end])
+        {
+            beginning++;
+        }
+            else
+            {
+                end--;
+            }
+        }
+        return max_area;
+    }
+};

--- a/TrimBinarySearchTree.cpp
+++ b/TrimBinarySearchTree.cpp
@@ -1,0 +1,23 @@
+class Solution {
+public:
+    TreeNode* trimBST(TreeNode* root, int low, int high) {
+        if(root==NULL)
+        {
+            return NULL;
+        }
+        else if(root->val >=low && root->val<=high)
+        {
+            root->right=trimBST(root->right,low,high);
+            root->left=trimBST(root->left,low,high);
+        }
+        else if(root->val <low)
+        {
+            return trimBST(root->right,low,high);
+        }
+        else 
+        {
+            return trimBST(root->left,low,high);
+        }
+        return root;
+    }
+};


### PR DESCRIPTION
Given the root of a binary search tree and the lowest and highest boundaries as low and high, trim the tree so that all its elements lies in [low, high]. Trimming the tree should not change the relative structure of the elements that will remain in the tree (i.e., any node's descendant should remain a descendant). It can be proven that there is a unique answer.

Return the root of the trimmed binary search tree. Note that the root may change depending on the given bounds.