### PR TITLE
Added Binary Search Tree Iterator

### DIFF
--- a/BinarySearchTreeIterator.cpp
+++ b/BinarySearchTreeIterator.cpp
@@ -1,0 +1,44 @@
+/**
+ * Definition for a binary tree node.
+ * struct TreeNode {
+ *     int val;
+ *     TreeNode *left;
+ *     TreeNode *right;
+ *     TreeNode() : val(0), left(nullptr), right(nullptr) {}
+ *     TreeNode(int x) : val(x), left(nullptr), right(nullptr) {}
+ *     TreeNode(int x, TreeNode *left, TreeNode *right) : val(x), left(left), right(right) {}
+ * };
+ */
+class BSTIterator {
+public:
+    vector<int>v;
+    int i=0;
+    void inorder(TreeNode *root)
+    {
+        if(root==NULL)
+        {
+            return;
+        }
+        inorder(root->left);
+        v.push_back(root->val);
+        inorder(root->right);
+    }
+    BSTIterator(TreeNode* root) {
+        inorder(root);
+    }
+    
+    int next() {
+        return v[i++];
+    }
+    
+    bool hasNext() {
+     return i<v.size();   
+    }
+};
+
+/**
+ * Your BSTIterator object will be instantiated and called as such:
+ * BSTIterator* obj = new BSTIterator(root);
+ * int param_1 = obj->next();
+ * bool param_2 = obj->hasNext();
+ */

--- a/ContainerWithMostWater
+++ b/ContainerWithMostWater
@@ -1,0 +1,22 @@
+class Solution {
+public:
+    int maxArea(vector<int>& height) {
+        int beginning=0, end=height.size()-1,max_area=0;
+    
+        
+        while(beginning<=end)
+        {
+        int minimum_height=min(height[beginning],height[end]);
+        max_area=max(minimum_height * (end-beginning) , max_area);
+        if(height[beginning]<=height[end])
+        {
+            beginning++;
+        }
+            else
+            {
+                end--;
+            }
+        }
+        return max_area;
+    }
+};

--- a/TrimBinarySearchTree.cpp
+++ b/TrimBinarySearchTree.cpp
@@ -1,0 +1,23 @@
+class Solution {
+public:
+    TreeNode* trimBST(TreeNode* root, int low, int high) {
+        if(root==NULL)
+        {
+            return NULL;
+        }
+        else if(root->val >=low && root->val<=high)
+        {
+            root->right=trimBST(root->right,low,high);
+            root->left=trimBST(root->left,low,high);
+        }
+        else if(root->val <low)
+        {
+            return trimBST(root->right,low,high);
+        }
+        else 
+        {
+            return trimBST(root->left,low,high);
+        }
+        return root;
+    }
+};


### PR DESCRIPTION
Implement the BSTIterator class that represents an iterator over the [in-order traversal](https://en.wikipedia.org/wiki/Tree_traversal#In-order_(LNR)) of a binary search tree (BST):

BSTIterator(TreeNode root) Initializes an object of the BSTIterator class. The root of the BST is given as part of the constructor. The pointer should be initialized to a non-existent number smaller than any element in the BST.
boolean hasNext() Returns true if there exists a number in the traversal to the right of the pointer, otherwise returns false.
int next() Moves the pointer to the right, then returns the number at the pointer.
Notice that by initializing the pointer to a non-existent smallest number, the first call to next() will return the smallest element in the BST.

You may assume that next() calls will always be valid. That is, there will be at least a next number in the in-order traversal when next() is called.